### PR TITLE
Supported v4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # redash-hands-on
 
 [![GitHub stars](https://img.shields.io/github/stars/kakakakakku/redash-hands-on.svg?style=for-the-badge)](https://github.com/kakakakakku/redash-hands-on/stargazers)
-[![Redash version](https://img.shields.io/badge/redash-v4.0.1-ff7964.svg?style=for-the-badge)](https://github.com/getredash/redash)
+[![Redash version](https://img.shields.io/badge/redash-v4.0.2-ff7964.svg?style=for-the-badge)](https://github.com/getredash/redash)
 
 ## 前提
 
@@ -12,7 +12,7 @@ Redash ハンズオン資料は以下の環境を前提に動作確認をして�
 
 ## 環境構築
 
-Docker Compose で Redash (v4.0.1) 環境を構築します．任意のディレクトリに kakakakakku/redash-hands-on リポジトリをクローンしましょう．
+Docker Compose で Redash (v4.0.2) 環境を構築します．任意のディレクトリに kakakakakku/redash-hands-on リポジトリをクローンしましょう．
 
 ```sh
 $ git clone https://github.com/kakakakakku/redash-hands-on.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 version: '2'
 services:
   server:
-    image: redash/redash:4.0.1.b4038
+    image: redash/redash:4.0.2.b4720
     command: server
     depends_on:
       - postgres
@@ -22,7 +22,7 @@ services:
       REDASH_COOKIE_SECRET: veryverysecret
       REDASH_WEB_WORKERS: 4
   worker:
-    image: redash/redash:4.0.1.b4038
+    image: redash/redash:4.0.2.b4720
     command: scheduler
     environment:
       PYTHONUNBUFFERED: 0


### PR DESCRIPTION
Supported v4.0.2 because v4.0.1 has security issue.

- https://twitter.com/getredash/status/1042660863675691009

![image](https://user-images.githubusercontent.com/1573290/45819434-425fa380-bd1f-11e8-8a74-3151b0fd0d07.png)